### PR TITLE
Add support for IPs masked via a Proxy

### DIFF
--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -157,17 +157,21 @@ class Base
 
     protected function getIpAddress()
     {
+    	$ip = null;
     	if (function_exists('apache_request_headers')) {
 		$headers = apache_request_headers();
-		if (isset($headers['X-Forwarded-For']) && !empty($headers['X-Forwarded-For']))
-			return reset(explode(',', $headers['X-Forwarded-For']));
-
-		if (isset($headers['HTTP_X_FORWARDED_FOR']) && !empty($headers['HTTP_X_FORWARDED_FOR']))
-			return reset(explode(',', $headers['HTTP_X_FORWARDED_FOR']));
-    	}
-
-	if (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR']))
-		return $_SERVER['REMOTE_ADDR'];
+		if (isset($headers['X-Forwarded-For']) && !empty($headers['X-Forwarded-For'])) {
+			$ip = reset(explode(',', $headers['X-Forwarded-For']));
+		} elseif (isset($headers['HTTP_X_FORWARDED_FOR']) && !empty($headers['HTTP_X_FORWARDED_FOR'])) {
+			$ip =  reset(explode(',', $headers['HTTP_X_FORWARDED_FOR']));
+		} else {
+			//
+		}
+    	} elseif (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR'])) {
+		$ip = $_SERVER['REMOTE_ADDR'];
+	} else {
+		//
+	}
 
 	return null;
     }

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -157,17 +157,19 @@ class Base
 
     protected function getIpAddress()
     {
+    	if (function_exists('apache_request_headers')) {
 		$headers = apache_request_headers();
 		if (isset($headers['X-Forwarded-For']) && !empty($headers['X-Forwarded-For']))
 			return reset(explode(',', $headers['X-Forwarded-For']));
 
 		if (isset($headers['HTTP_X_FORWARDED_FOR']) && !empty($headers['HTTP_X_FORWARDED_FOR']))
 			return reset(explode(',', $headers['HTTP_X_FORWARDED_FOR']));
+    	}
 
-		if (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR']))
-			return $_SERVER['REMOTE_ADDR'];
+	if (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR']))
+		return $_SERVER['REMOTE_ADDR'];
 
-		return null;
+	return null;
     }
 
     protected function sendRequest($endpoint, $params = array())

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -157,10 +157,17 @@ class Base
 
     protected function getIpAddress()
     {
-        if (isset($_SERVER['REMOTE_ADDR'])) {
-            return $_SERVER['REMOTE_ADDR'];
-        }
-        return null;
+		$headers = apache_request_headers();
+		if (isset($headers['X-Forwarded-For']) && !empty($headers['X-Forwarded-For']))
+			return reset(explode(',', $headers['X-Forwarded-For']));
+
+		if (isset($headers['HTTP_X_FORWARDED_FOR']) && !empty($headers['HTTP_X_FORWARDED_FOR']))
+			return reset(explode(',', $headers['HTTP_X_FORWARDED_FOR']));
+
+		if (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR']))
+			return $_SERVER['REMOTE_ADDR'];
+
+		return null;
     }
 
     protected function sendRequest($endpoint, $params = array())

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -171,7 +171,8 @@ class Base
             if (isset($_SERVER[$var])) {
                 $ip = $_SERVER[$var];
                 if ($ip && !in_array($ip, $invalid_ips)) {
-                    return reset(explode(',', $ip));
+                    $ips = explode(',', $ip);
+                    return reset($ips);
                 }
             }
         }


### PR DESCRIPTION
If the user is behind a load balancer or proxy, $_SERVER['REMOTE_ADDR'] would be the IP address of the Proxy, not the user. Use the Apache headers first and fall back to $_SERVER['REMOTE_ADDR'] if necessary