### PR TITLE
Throw specific exceptions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
             "SeatGeek": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SeatGeek\\Sixpack\\Test\\": "tests/"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="true"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="true"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="SeatGeek Sixpack suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -3,6 +3,7 @@
 namespace SeatGeek\Sixpack\Session;
 
 use SeatGeek\Sixpack\Response;
+use SeatGeek\Sixpack\Session\Exception\InvalidExperimentNameException;
 use SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException;
 use \InvalidArgumentException;
 
@@ -209,7 +210,7 @@ class Base
     protected function sendRequest($endpoint, $params = array())
     {
         if (isset($params["experiment"]) && !preg_match('#^[a-z0-9][a-z0-9\-_ ]*$#i', $params["experiment"])) {
-            throw new \Exception("Invalid Experiment Name: " . $params["experiment"]);
+            throw new InvalidExperimentNameException($params["experiment"]);
         }
 
         $params = array_merge(array(

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -3,6 +3,7 @@
 namespace SeatGeek\Sixpack\Session;
 
 use SeatGeek\Sixpack\Response;
+use SeatGeek\Sixpack\Session\Exception\InvalidForcedException;
 
 class Base
 {
@@ -86,13 +87,22 @@ class Base
         return false;
     }
 
+    /**
+     * Force the alternative
+     *
+     * @param string $experiment
+     * @param array $alternatives
+     * @throws \SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException
+     *   if an alternative is requested that doesn't exist
+     * @return array
+     */
     protected function forceAlternative($experiment, $alternatives)
     {
         $forceKey = "sixpack-force-" . $experiment;
         $forcedAlt = $_GET[$forceKey];
 
         if (!in_array($forcedAlt, $alternatives)) {
-            throw new \Exception("Invalid forced alternative");
+            throw new InvalidForcedAlternativeException([$forcedAlt, $alternatives]);
         }
 
         $mockJson = json_encode(array(

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -123,6 +123,15 @@ class Base
         return $this->sendRequest('/_status');
     }
 
+    /**
+     * convert
+     *
+     * @param string $experiment
+     * @param mixed $kpi
+     * @throws \SeatGeek\Sixpack\Session\Exception\InvalidExperimentNameException
+     *   if the experiment name is invalid
+     * @return \SeatGeek\Sixpack\Response\Conversion
+     */
     public function convert($experiment, $kpi = null)
     {
         list($rawResp, $meta) = $this->sendRequest('convert', array(
@@ -137,6 +146,8 @@ class Base
      *
      * @param string $experiment name of the experiment
      * @param array $alternatives the alternatives to pick from
+     * @throws \SeatGeek\Sixpack\Session\Exception\InvalidExperimentNameException
+     *   if the experiment name is invalid
      * @throws \InvalidArgumentException if less than two alternatives are specified
      * @throws \InvalidArgumentException if an alternative has an invalid name
      * @throws \InvalidArgumentException if the traffic fraction is less than 0 or greater
@@ -207,6 +218,15 @@ class Base
         return null;
     }
 
+    /**
+     * Send the request to sixpack
+     *
+     * @param string $endpoint api end point
+     * @param array $params
+     * @throws \SeatGeek\Sixpack\Session\Exception\InvalidExperimentNameException
+     *   if the experiment name is invalid
+     * @return array
+     */
     protected function sendRequest($endpoint, $params = array())
     {
         if (isset($params["experiment"]) && !preg_match('#^[a-z0-9][a-z0-9\-_ ]*$#i', $params["experiment"])) {

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -3,7 +3,7 @@
 namespace SeatGeek\Sixpack\Session;
 
 use SeatGeek\Sixpack\Response;
-use SeatGeek\Sixpack\Session\Exception\InvalidForcedException;
+use SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException;
 use \InvalidArgumentException;
 
 class Base
@@ -100,7 +100,7 @@ class Base
     protected function forceAlternative($experiment, $alternatives)
     {
         $forceKey = "sixpack-force-" . $experiment;
-        $forcedAlt = $_GET[$forceKey];
+        $forcedAlt = isset($_GET[$forceKey]) ? $_GET[$forceKey] : null;
 
         if (!in_array($forcedAlt, $alternatives)) {
             throw new InvalidForcedAlternativeException([$forcedAlt, $alternatives]);

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -154,7 +154,7 @@ class Base
      *   than 1
      * @throws \SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException
      *   if an alternative is requested that doesn't exist
-     * @return array
+     * @return \SeatGeek\Sixpack\Response\Participation
      */
     public function participate($experiment, $alternatives, $traffic_fraction = 1)
     {

--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -4,6 +4,7 @@ namespace SeatGeek\Sixpack\Session;
 
 use SeatGeek\Sixpack\Response;
 use SeatGeek\Sixpack\Session\Exception\InvalidForcedException;
+use \InvalidArgumentException;
 
 class Base
 {
@@ -130,20 +131,33 @@ class Base
         return new Response\Conversion($rawResp, $meta);
     }
 
+    /**
+     * Participate in an experiment
+     *
+     * @param string $experiment name of the experiment
+     * @param array $alternatives the alternatives to pick from
+     * @throws \InvalidArgumentException if less than two alternatives are specified
+     * @throws \InvalidArgumentException if an alternative has an invalid name
+     * @throws \InvalidArgumentException if the traffic fraction is less than 0 or greater
+     *   than 1
+     * @throws \SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException
+     *   if an alternative is requested that doesn't exist
+     * @return array
+     */
     public function participate($experiment, $alternatives, $traffic_fraction = 1)
     {
         if (count($alternatives) < 2) {
-            throw new \Exception("At least two alternatives are required");
+            throw new InvalidArgumentException("At least two alternatives are required");
         }
 
         foreach ($alternatives as $alt) {
             if (!preg_match('#^[a-z0-9][a-z0-9\-_ ]*$#i', $alt)) {
-                throw new \Exception("Invalid Alternative Name: {$alt}");
+                throw new InvalidArgumentException("Invalid Alternative Name: {$alt}");
             }
         }
 
         if (floatval($traffic_fraction) < 0 || floatval($traffic_fraction) > 1) {
-            throw new \Exception("Invalid Traffic Fraction");
+            throw new InvalidArgumentException("Invalid Traffic Fraction");
         }
 
         if ($this->isForced($experiment)) {

--- a/src/SeatGeek/Sixpack/Session/Exception/InvalidExperimentNameException.php
+++ b/src/SeatGeek/Sixpack/Session/Exception/InvalidExperimentNameException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SeatGeek\Sixpack\Session\Exception;
+
+use \Exception;
+
+/**
+ * Used when an experiement name is deemed invalid
+ */
+class InvalidExperimentNameException extends Exception
+{
+    /**
+     * The sprintf pattern for when an exception is thrown
+     *
+     * @var string
+     */
+    protected $messageTemplate = "The experiement name \"%s\" is invalid";
+
+    /**
+     * Constructor
+     *
+     * @param string|array If passed, it's the experiment name
+     * @param int $code The exception code
+     * @param \Exception $previous The previous exception
+     */
+    public function __construct($message = null, $code = 0, Exception $previous = null)
+    {
+        if ($message) {
+            $message = sprintf($this->messageTemplate, $message);
+        }
+        return parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/SeatGeek/Sixpack/Session/Exception/InvalidExperimentNameException.php
+++ b/src/SeatGeek/Sixpack/Session/Exception/InvalidExperimentNameException.php
@@ -19,7 +19,7 @@ class InvalidExperimentNameException extends Exception
     /**
      * Constructor
      *
-     * @param string|array If passed, it's the experiment name
+     * @param string|null If passed, it's the experiment name
      * @param int $code The exception code
      * @param \Exception $previous The previous exception
      */

--- a/src/SeatGeek/Sixpack/Session/Exception/InvalidForcedAlternativeException.php
+++ b/src/SeatGeek/Sixpack/Session/Exception/InvalidForcedAlternativeException.php
@@ -7,14 +7,14 @@ use \Exception;
 /**
  * Used when a forced alternative is requested that doesn't exist
  */
-class InvalidForcedException extends Exception
+class InvalidForcedAlternativeException extends Exception
 {
     /**
      * The sprintf pattern for when an exception is thrown
      *
      * @var string
      */
-    protected $messageTemplate = "The alternative %s is not one of the possibilities (%s)";
+    protected $messageTemplate = "The alternative \"%s\" is not one of the possibilities (%s)";
 
     /**
      * Constructor
@@ -28,7 +28,7 @@ class InvalidForcedException extends Exception
         if ($message && is_array($message)) {
             $message += ['the alternative', ['the', 'possibilities']];
             $message[1] = implode(', ', $message[1]);
-            $message = sprintf($this->messageTemplate, $message);
+            $message = vsprintf($this->messageTemplate, $message);
         }
         return parent::__construct($message, $code, $previous);
     }

--- a/src/SeatGeek/Sixpack/Session/Exception/InvalidForcedAlternativeException.php
+++ b/src/SeatGeek/Sixpack/Session/Exception/InvalidForcedAlternativeException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SeatGeek\Sixpack\Session\Exception;
+
+use \Exception;
+
+/**
+ * Used when a forced alternative is requested that doesn't exist
+ */
+class InvalidForcedException extends Exception
+{
+    /**
+     * The sprintf pattern for when an exception is thrown
+     *
+     * @var string
+     */
+    protected $messageTemplate = "The alternative %s is not one of the possibilities (%s)";
+
+    /**
+     * Constructor
+     *
+     * @param string|array Either the literal message, or arguments for the message template
+     * @param int $code The exception code
+     * @param \Exception $previous The previous exception
+     */
+    public function __construct($message = [], $code = 0, Exception $previous = null)
+    {
+        if ($message && is_array($message)) {
+            $message += ['the alternative', ['the', 'possibilities']];
+            $message[1] = implode(', ', $message[1]);
+            $message = sprintf($this->messageTemplate, $message);
+        }
+        return parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -59,7 +59,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
      * Valid 'foo', invalid '-foo', '@bar'
      *
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid Alternative Name: @ne
+     * @expectedExceptionMessage Invalid Alternative Name: $ne
      */
     public function testParticipateInvalidAlternativeName()
     {
@@ -68,6 +68,40 @@ class BaseTest extends PHPUnit_Framework_TestCase
             ->setMethods(['sendRequest'])
             ->getMock();
 
-        $base->participate('one', ['@ne', 'two']);
+        $base->participate('one', ['$ne', 'two']);
+    }
+
+    /**
+     * Test participate with invalid traffic fraction
+     *
+     * Valid 'foo', invalid '-foo', '@bar'
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid Traffic Fraction
+     * @dataProvider invalidTrafficFractionProvider
+     */
+    public function testParticipateInvalidTrafficFraction($fraction)
+    {
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $base->participate('one', ['one', 'two'], $fraction);
+    }
+
+    /**
+     * invalidTrafficFractionProvider
+     *
+     * @return array
+     */
+    public function invalidTrafficFractionProvider()
+    {
+        return [
+            [-1],
+            [-0.01],
+            [1.01],
+            [2]
+        ];
     }
 }

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -36,4 +36,20 @@ class BaseTest extends PHPUnit_Framework_TestCase
         $return = $base->participate('the', ['the', 'alternative'], 0.42);
         $this->assertInstanceOf('SeatGeek\Sixpack\Response\Participation', $return);
     }
+
+    /**
+     * testParticipateTooFewAlternatives
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage At least two alternatives are required
+     */
+    public function testParticipateTooFewAlternatives()
+    {
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $base->participate('one', ['one']);
+    }
 }

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -122,4 +122,22 @@ class BaseTest extends PHPUnit_Framework_TestCase
 
         $base->participate('experiment', ['one', 'two']);
     }
+
+    /**
+     * Verify what happens with a bad experiment name
+     *
+     * @expectedException \SeatGeek\Sixpack\Session\Exception\InvalidExperimentNameException
+     * @expectedExceptionMessage The experiement name "experiments; the final frontier" is invalid
+     */
+    public function testParticipateInvalidExperimentName()
+    {
+        $_GET['sixpack-force-experiment'] = 'not configured';
+
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['nothing'])
+            ->getMock();
+
+        $base->participate('experiments; the final frontier', ['one', 'two']);
+    }
 }

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -50,7 +50,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
             ->setMethods(['sendRequest'])
             ->getMock();
 
-        $base->participate('one', ['one']);
+        $base->participate('experiment', ['one']);
     }
 
     /**
@@ -68,7 +68,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
             ->setMethods(['sendRequest'])
             ->getMock();
 
-        $base->participate('one', ['$ne', 'two']);
+        $base->participate('experiment', ['$ne', 'two']);
     }
 
     /**
@@ -87,7 +87,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
             ->setMethods(['sendRequest'])
             ->getMock();
 
-        $base->participate('one', ['one', 'two'], $fraction);
+        $base->participate('experiment', ['one', 'two'], $fraction);
     }
 
     /**
@@ -103,5 +103,23 @@ class BaseTest extends PHPUnit_Framework_TestCase
             [1.01],
             [2]
         ];
+    }
+
+    /**
+     * Verify what happens with an unconfigured forced choice
+     *
+     * @expectedException \SeatGeek\Sixpack\Session\Exception\InvalidForcedAlternativeException
+     * @expectedExceptionMessage The alternative "not configured" is not one of the possibilities (one, two)
+     */
+    public function testParticipateInvalidForcedAlternative()
+    {
+        $_GET['sixpack-force-experiment'] = 'not configured';
+
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $base->participate('experiment', ['one', 'two']);
     }
 }

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -2,8 +2,38 @@
 
 namespace SeatGeek\Sixpack\Test\Session;
 
+use SeatGeek\Sixpack\Session\Base;
 use \PHPUnit_Framework_TestCase;
 
 class BaseTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * Verify the mocked method call to sendRequest, and that the return value
+     * is the right class
+     */
+    public function testParticipateValidArgs()
+    {
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $mockedResponse = [
+            'raw response',
+            ['meta', 'data']
+        ];
+        $base->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                'participate',
+                [
+                    'experiment' => 'the',
+                    'alternatives' => ['the', 'alternative'],
+                    'traffic_fraction' => '0.42'
+                ]
+            )->will($this->returnValue($mockedResponse));
+
+        $return = $base->participate('the', ['the', 'alternative'], 0.42);
+        $this->assertInstanceOf('SeatGeek\Sixpack\Response\Participation', $return);
+    }
 }

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SeatGeek\Sixpack\Test\Session;
+
+use \PHPUnit_Framework_TestCase;
+
+class BaseTest extends PHPUnit_Framework_TestCase
+{
+}

--- a/tests/Session/BaseTest.php
+++ b/tests/Session/BaseTest.php
@@ -38,7 +38,7 @@ class BaseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * testParticipateTooFewAlternatives
+     * Test participate with too few alternatives
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage At least two alternatives are required
@@ -51,5 +51,23 @@ class BaseTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $base->participate('one', ['one']);
+    }
+
+    /**
+     * Test participate with badly named alternatives
+     *
+     * Valid 'foo', invalid '-foo', '@bar'
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid Alternative Name: @ne
+     */
+    public function testParticipateInvalidAlternativeName()
+    {
+        $base = $this->getMockBuilder('SeatGeek\Sixpack\Session\Base')
+            ->disableOriginalConstructor()
+            ->setMethods(['sendRequest'])
+            ->getMock();
+
+        $base->participate('one', ['@ne', 'two']);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once 'vendor/autoload.php';


### PR DESCRIPTION
Make it possible to catch runtime problems without needing to string-match the message.

There's plenty more cleanup/refactoring I could do, this aught to be enough for now.