### PR TITLE
Fixed incompatible syntax with PHP 5.3

### DIFF
--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -104,7 +104,7 @@ class Base
         $forcedAlt = isset($_GET[$forceKey]) ? $_GET[$forceKey] : null;
 
         if (!in_array($forcedAlt, $alternatives)) {
-            throw new InvalidForcedAlternativeException([$forcedAlt, $alternatives]);
+            throw new InvalidForcedAlternativeException(array($forcedAlt, $alternatives));
         }
 
         $mockJson = json_encode(array(


### PR DESCRIPTION
I know it's a weird that change but some legacy systems still work with PHP 5.3 and according to your `composer.json` you still support PHP 5.3.